### PR TITLE
Fix stream input device

### DIFF
--- a/software/swhear.py
+++ b/software/swhear.py
@@ -154,6 +154,7 @@ class Ear(object):
         self.keepRecording=True # set this to False later to terminate stream
         self.dataFiltered=None #same
         self.stream=self.p.open(format=pyaudio.paInt16,channels=1,
+                      input_device_index=self.device
                       rate=self.rate,input=True,frames_per_buffer=self.chunk)
         self.stream_thread_new()
 

--- a/software/swhear.py
+++ b/software/swhear.py
@@ -154,7 +154,7 @@ class Ear(object):
         self.keepRecording=True # set this to False later to terminate stream
         self.dataFiltered=None #same
         self.stream=self.p.open(format=pyaudio.paInt16,channels=1,
-                      input_device_index=self.device
+                      input_device_index=self.device,
                       rate=self.rate,input=True,frames_per_buffer=self.chunk)
         self.stream_thread_new()
 


### PR DESCRIPTION
When reading ECG data from audio device, the device was not specified, so it only reads actual data from default device. This fix passes the correct audio device to the stream open.